### PR TITLE
Fix Greedy Meshing and for New WebGL Version

### DIFF
--- a/src/TextureManager.js
+++ b/src/TextureManager.js
@@ -48,7 +48,7 @@ export class TextureManager {
         this.material = new ShaderMaterial( {
             uniforms: {
                 'uTime': { value: 0.0 },
-                texture: { value: this.texture},
+                textureSamp: { value: this.texture},
                 texturesEnabled: { value: this.texturesEnabled },
             },
             vertexColors:VertexColors,
@@ -73,7 +73,7 @@ export class TextureManager {
             } 
             `,
             fragmentShader: `
-                uniform sampler2D texture;
+                uniform sampler2D textureSamp;
                 uniform float uTime;
                 uniform bool texturesEnabled;
                 varying vec2 vUv;
@@ -92,10 +92,11 @@ export class TextureManager {
                     float cframe2 = floor(cframe); 
                     sr.x = sr.x + cframe2*sr.z;
                     fuv.x = sr.x + fract(vUv.x*vRepeat.x)*sr.z;
-                    fuv.y = sr.y + vUv.y*sr.w;
+                    fuv.y = sr.y + fract(vUv.y*vRepeat.y)*sr.w;
                     vec4 color = vec4(1.0,1.0,1.0,1.0);
+                    
                     if(texturesEnabled) {
-                        color = texture2D(texture, fuv);
+                        color = texture2D(textureSamp, fuv);
                     }
                     color = color*(vOcclusion);
                     gl_FragColor = vec4(color.xyz,1.0);


### PR DESCRIPTION
Fixes texture repeat for Greedy Mesh, rename Texture to TextureSamp since it is a reserved word in some new versions of webgl